### PR TITLE
Fix version check to work properly on iOS 8

### DIFF
--- a/MessageBarLib/MessageView.cs
+++ b/MessageBarLib/MessageView.cs
@@ -238,9 +238,7 @@ namespace MessageBar
 
 		bool IsRunningiOS7OrLater ()
 		{
-			string systemVersion = UIDevice.CurrentDevice.SystemVersion;
-
-			return systemVersion.Contains ("7");
+            return UIDevice.CurrentDevice.CheckSystemVersion(7, 0);
 		}
 	}
 }


### PR DESCRIPTION
The existing version check only accounts for iOS 7, so the library doesn't work properly in iOS 8. This updates it so it works on iOS 7+, as the method name implies.