### PR TITLE
Version checking did not consider two digit version number.

### DIFF
--- a/MessageBarLib/MessageView.cs
+++ b/MessageBarLib/MessageView.cs
@@ -438,9 +438,7 @@ namespace MessageBar
 		/// </returns>
 		private static bool IsRunningiOS7OrLater()
 		{
-			string systemVersion = UIDevice.CurrentDevice.SystemVersion;
-
-			return IsRunningiOS8OrLater() || systemVersion.Contains("7");
+			return UIDevice.CurrentDevice.CheckSystemVersion(7, 0);
 		}
 
 		/// <summary>
@@ -451,9 +449,7 @@ namespace MessageBar
 		/// </returns>
 		private static bool IsRunningiOS8OrLater()
 		{
-			var systemVersion = int.Parse(UIDevice.CurrentDevice.SystemVersion.Substring(0, 1));
-
-			return systemVersion >= 8;
+			return UIDevice.CurrentDevice.CheckSystemVersion(8, 0);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Version checking was only checking the first character of the version string. In the case of iOS 10, it would only look at the 1. This caused both version checking methods to return false when they should of been true.
